### PR TITLE
Dead-Zone 테이블 구현

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -4,6 +4,7 @@ import config from '../config/configVariable';
 import { isEmpty } from 'lodash';
 import { findMemberById } from '../repository/member';
 import { typeGuard } from '../util/typeGuard';
+import redisClient from '../db/redis';
 
 export const authCheck = async (
   request: Request,
@@ -27,6 +28,13 @@ export const authCheck = async (
     const findMember = await findMemberById(memberId);
 
     if (isEmpty(findMember)) {
+      return response
+        .status(403)
+        .json({ message: '유효하지 않은 Token입니다.' });
+    }
+
+    const deadTokenValue = await redisClient.get(`dead:${memberId}`);
+    if (!isEmpty(deadTokenValue)) {
       return response
         .status(403)
         .json({ message: '유효하지 않은 Token입니다.' });


### PR DESCRIPTION
로그아웃시 만료되지 않은 access Token의 사용을 방지하고자 레디스에 deadzone 테이블을 만들어 memberId를 저장하는 로직을 구현하였습니다.

- 로그인시 dead-zone 체크 후 정보가 있으면 삭제 로직 추가
- 로그아웃시 dead-zone에 memberId를 등록(access-token의 인증시간만큼 유효기간 설정)
- 인증 체크시 dead-zone에 정보 유무를 판별하여 인증 체크

This cloases #21 